### PR TITLE
Improving speed by removing seaborn

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import matplotlib.pyplot as plt
 import numpy as np
-import seaborn as sns
 from skyrmions import *
 from scipy.stats.kde import gaussian_kde
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
 from skyrmions import *
+from scipy.stats.kde import gaussian_kde
 
 # Function implementing the deflection of an electron crossing the spin structure 
 # perpendicular to the plane by the Lorentz force. The deflection is proportional
@@ -27,11 +28,19 @@ xim, yim = deflect(X, Y, spinx, spiny, scale=0.1)
 xim = xim.flatten()
 yim = yim.flatten()
 
-# Plot distribution of electrons in 2D on detector using KDE. More information:   
-# https://seaborn.pydata.org/generated/seaborn.kdeplot.html
-# Limit lowest and highest greyscale value by using vmin and vmax parameters.
-sns.kdeplot(xim, yim, cmap='gray', n_levels=300, bw=0.05, shade=True,
-            clip=((-1.6, 1.6), (-1.6, 1.6)), ax=ax1)
+# taken from https://stackoverflow.com/a/36958298/5934316
+k = gaussian_kde(np.vstack([xim, yim]))
+xi, yi = np.mgrid[xim.min():xim.max():xim.size**0.5*1j,
+                  yim.min():yim.max():yim.size**0.5*1j]
+zi = k(np.vstack([xi.flatten(), yi.flatten()]))
+
+vmin = 0.073
+vmax = 0.077
+d = 1.25
+ax1.pcolormesh(xi, yi, zi.reshape(xi.shape), shading='auto', 
+               cmap="gray", vmin=vmin, vmax=vmax)
+ax1.set_xlim((-d, d))
+ax1.set_ylim((-d, d))
 
 # Define color-array containing the directions of spins in rad
 # Set min and max values to +/-pi to ensure the same color map for every structure.
@@ -47,22 +56,19 @@ ax2.set_facecolor('k')
 ax2.quiver(X[::skip, ::skip], Y[::skip, ::skip], spinx[::skip, ::skip], spiny[::skip, ::skip],
            c_array, scale=3, width=0.004, minlength=0, pivot='mid', cmap='hsv')
 
+d = 1.5
+ax2.set_xlim((-d, d))
+ax2.set_ylim((-d, d))
+
 # Format axes to not show ticks and labels and remove spaces
 for ax in [ax1, ax2]:
-    ax.set_xlim(-1.5, 1.5)
-    ax.set_ylim(-1.5, 1.5)
-    
-    ax.set_xticks([])
-    ax.set_yticks([])
-    
-    ax.set_xticklabels([])
-    ax.set_yticklabels([])
+    ax.axis("off")
 
 plt.subplots_adjust(top=1.0,
-bottom=0.0,
-left=0.0,
-right=1.0,
-hspace=0,
-wspace=0)
+                    bottom=0.0,
+                    left=0.0,
+                    right=1.0,
+                    hspace=0,
+                    wspace=0)
 
 plt.show()


### PR DESCRIPTION
Removing `seaborn.kde()` plot function, calculating kde manually using scipy, then plotting via matplotlib. Execution time is now reduced by approx 60%